### PR TITLE
Optimize API key utilities and message serialization

### DIFF
--- a/src/app/llm/providers.py
+++ b/src/app/llm/providers.py
@@ -197,10 +197,10 @@ class OpenAIProvider:
                     mapped_type = "output_text" if role == "assistant" else "input_text"
                     parts.append({"type": mapped_type, "text": text_value})
 
-            if not parts:
-                parts.append({"type": "input_text", "text": ""})
-
-            converted.append({"role": role, "content": parts})
+            converted.append({
+                "role": role,
+                "content": parts or [{"type": "input_text", "text": ""}],
+            })
 
         return converted
 

--- a/src/chat/services.py
+++ b/src/chat/services.py
@@ -18,7 +18,7 @@ def _serialize_messages(messages: Iterable[Message]) -> list[dict[str, Any]]:
     for message in messages:
         parts: list[dict[str, Any]] = []
 
-        content = getattr(message, "content", None)
+        content = getattr(message, "content", "") or ""
         if content:
             parts.append({"type": "text", "text": content})
 
@@ -39,10 +39,10 @@ def _serialize_messages(messages: Iterable[Message]) -> list[dict[str, Any]]:
                 }
             )
 
-        if not parts:
-            parts = [{"type": "text", "text": ""}]
-
-        serialized.append({"role": message.role, "content": parts})
+        serialized.append({
+            "role": message.role,
+            "content": parts or [{"type": "text", "text": ""}],
+        })
 
     return serialized
 
@@ -54,10 +54,7 @@ _GEMINI_MODEL_ALIASES: dict[str, str] = {
 
 
 def _normalize_model_name(platform: str, model_name: str | None) -> str | None:
-    if not model_name:
-        return None
-
-    normalized = model_name.strip()
+    normalized = (model_name or "").strip()
     if not normalized:
         return None
 


### PR DESCRIPTION
## Summary
- streamline API key retrieval and validation helpers
- simplify chat message serialization defaults
- ensure OpenAI response conversion provides a fallback content part

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa907ff0988323a05a405a5712b208