### PR TITLE
Improve chat message scrolling and image upload icon

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -172,9 +172,11 @@ body {
 .chat-ui {
   display: flex;
   flex-direction: column;
+  flex: 1 1 70%;
   width: 70%;
   background: linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(17, 24, 39, 0.98));
   min-height: 0;
+  max-height: 100%;
 }
 
 .platform-switcher {
@@ -243,6 +245,7 @@ body {
   overflow-y: auto;
   padding: 1.5rem;
   min-height: 0;
+  max-height: 100%;
 }
 
 .message {
@@ -343,6 +346,12 @@ body {
   background: var(--background-tertiary);
   color: var(--text-primary);
   border: 1px solid var(--border-subtle);
+}
+
+.chat-input .image-upload-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: inherit;
 }
 
 .image-preview {


### PR DESCRIPTION
## Summary
- adjust the chat layout flex behavior so the message list can scroll inside the chat panel
- size the image upload button icon to remain visible inside the circular button

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68faaf1ed9c88323a8d29061cc397b22