### PR TITLE
Restyle login and registration pages with dark theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -659,3 +659,172 @@ button {
 .modal > div:last-of-type:hover {
   color: var(--danger);
 }
+
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.25), transparent 55%),
+    var(--background-primary);
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.95), rgba(11, 18, 32, 0.9));
+  border-radius: 24px;
+  padding: 2.5rem 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 25px 45px rgba(8, 11, 19, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  backdrop-filter: blur(18px);
+  color: var(--text-primary);
+}
+
+.auth-title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--text-primary);
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auth-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.auth-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-input-wrapper ion-icon {
+  color: var(--text-secondary);
+  font-size: 1.2rem;
+}
+
+.auth-input-wrapper input,
+.auth-select {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: 'Helvetica', 'Arial', sans-serif;
+}
+
+.auth-input-wrapper input::placeholder {
+  color: rgba(148, 163, 184, 0.5);
+}
+
+.auth-input-wrapper:focus-within {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.auth-select {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(30, 41, 59, 0.75);
+  appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-select:focus {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.auth-terms {
+  display: flex;
+  align-items: flex-start;
+}
+
+.auth-terms-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.auth-terms-label input {
+  margin-top: 0.15rem;
+  accent-color: var(--accent-primary);
+}
+
+.auth-terms-label a {
+  color: var(--accent-secondary);
+  text-decoration: none;
+}
+
+.auth-terms-label a:hover {
+  text-decoration: underline;
+}
+
+.auth-submit {
+  margin-top: 0.5rem;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: var(--text-primary);
+  border: none;
+  border-radius: 18px;
+  padding: 0.9rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.35);
+}
+
+.auth-footer {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.auth-footer a {
+  color: var(--accent-secondary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.auth-footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  .auth-card {
+    padding: 2rem 1.75rem;
+  }
+
+  .auth-title {
+    font-size: 1.5rem;
+  }
+}

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import axiosInstance from './axiosInstance';
 import AuthErrorDisplay from './AuthErrorDisplay';
-import { API_URL } from './config';
 
 function Login() {
     const [userData, setUserData] = useState({
@@ -46,34 +45,47 @@ function Login() {
     };
 
     return (
-        <div className='screen-1wrap'>
-            <form onSubmit={handleSubmit}>
-        <div className="screen-1">
-        <h2>Вхід в акаунт</h2>
-  <div className="email">
-    <label for="email">Логін</label>
-    <div className="sec-2">
-      <ion-icon name="mail-outline"></ion-icon>
-      <input type="text" name="username" value={userData.username} onChange={handleChange} placeholder="Логін"/>
-    </div>
-  </div>
-  <div className="password">
-    <label for="password">Пароль</label>
-    <div className="sec-2">
-      <ion-icon name="lock-closed-outline"></ion-icon>
-      <input className="pas" type="password" name="password" placeholder="···" value={userData.password} onChange={handleChange}/>
-      <ion-icon className="show-hide" name="eye-outline"></ion-icon>
-    </div>
-
-  </div>
-  <AuthErrorDisplay error={error} errorMessage={errorMessage} />
-  <button className="login">Ввійти </button>
-  
-  <div className="footer1"><span><a href='/users/register'>Зареєструватися</a></span><span></span></div>
-  
-</div>
-</form>
-</div>
+        <div className='auth-page'>
+            <form className="auth-card" onSubmit={handleSubmit}>
+                <h2 className="auth-title">Вхід в акаунт</h2>
+                <div className="auth-field">
+                    <label className="auth-label" htmlFor="login-username">Логін</label>
+                    <div className="auth-input-wrapper">
+                        <ion-icon name="mail-outline"></ion-icon>
+                        <input
+                            id="login-username"
+                            type="text"
+                            name="username"
+                            value={userData.username}
+                            onChange={handleChange}
+                            placeholder="Логін"
+                        />
+                    </div>
+                </div>
+                <div className="auth-field">
+                    <label className="auth-label" htmlFor="login-password">Пароль</label>
+                    <div className="auth-input-wrapper">
+                        <ion-icon name="lock-closed-outline"></ion-icon>
+                        <input
+                            id="login-password"
+                            className="auth-password"
+                            type="password"
+                            name="password"
+                            placeholder="···"
+                            value={userData.password}
+                            onChange={handleChange}
+                        />
+                        <ion-icon className="show-hide" name="eye-outline"></ion-icon>
+                    </div>
+                </div>
+                <AuthErrorDisplay error={error} errorMessage={errorMessage} />
+                <button className="auth-submit" type="submit">Ввійти</button>
+                <div className="auth-footer">
+                    <span>Немає акаунту?</span>
+                    <a href='/users/register'>Зареєструватися</a>
+                </div>
+            </form>
+        </div>
     );
 }
 

--- a/frontend/src/Register.js
+++ b/frontend/src/Register.js
@@ -1,21 +1,18 @@
 import React, { useState } from 'react';
 import axiosInstance from './axiosInstance';
-import { FaUniregistry } from 'react-icons/fa';
-import { API_URL } from './config';
 
 function Register() {
-
     const [userData, setUserData] = useState({
         username: '',
         password: '',
         user_type: 'student'
     });
-    const handleCheckboxChange = (e) => {
-      setAgree(e.target.checked);
-  };
-
     const [agree, setAgree] = useState(false);
-    
+
+    const handleCheckboxChange = (e) => {
+        setAgree(e.target.checked);
+    };
+
     const handleChange = (e) => {
         setUserData({ ...userData, [e.target.name]: e.target.value });
     };
@@ -23,21 +20,24 @@ function Register() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (!agree) {
-          alert("Ви повинні погодитися з правилами користування чатботом.");
-          return;
-      }
-      if (!userData.username) {
-        alert("Введіть ім'я");
-        return;
-}
-if (!userData.password) {
-  alert("Введіть пароль");
-  return;
-}
-if (!userData.user_type) {
-  alert("Оберіть тип користувача ще раз");
-  return;
-}
+            alert("Ви повинні погодитися з правилами користування чатботом.");
+            return;
+        }
+
+        if (!userData.username) {
+            alert("Введіть ім'я");
+            return;
+        }
+
+        if (!userData.password) {
+            alert("Введіть пароль");
+            return;
+        }
+
+        if (!userData.user_type) {
+            alert("Оберіть тип користувача ще раз");
+            return;
+        }
 
         try {
             const response = await axiosInstance.post(`/users/register/`, userData);
@@ -60,46 +60,70 @@ if (!userData.user_type) {
     };
 
     return (
-        <div className='screen-1wrap'>
-            <form onSubmit={handleSubmit}>
-        <div className="screen-1">
-        <h2>Реєстрація</h2>
-  <div className="email">
-    <label for="email">Логін</label>
-    <div className="sec-2">
-      <ion-icon name="mail-outline"></ion-icon>
-      <input type="text" name="username" value={userData.username} onChange={handleChange} placeholder="Придумайте логін"/>
-    </div>
-  </div>
-  <div className="password">
-    <label for="password">Пароль</label>
-    <div className="sec-2">
-      <ion-icon name="lock-closed-outline"></ion-icon>
-      <input className="pas" type="password" name="password" placeholder="·········" value={userData.password} onChange={handleChange}/>
-      <ion-icon className="show-hide" name="eye-outline"></ion-icon>
-
-    </div>
-
-  </div>
-
-  <div className="type">
-    <label htmlFor="role">Оберіть роль:</label>
-                <select id="role" type="user_type" name="user_type" value={userData.user_type} defaultValue="option2" onChange={handleChange}>
-                    <option value="student">Студент </option>
-                    <option value="teacher">Викладач</option>
-                </select>
-                </div>
-                <div className="terms">
-                        <input type="checkbox" id="agree" checked={agree} onChange={handleCheckboxChange} />
-                        <label htmlFor="agree">Я погоджуюся з <a href='/rules'>правилами користування чатботом</a></label>
+        <div className='auth-page'>
+            <form className="auth-card" onSubmit={handleSubmit}>
+                <h2 className="auth-title">Реєстрація</h2>
+                <div className="auth-field">
+                    <label className="auth-label" htmlFor="register-username">Логін</label>
+                    <div className="auth-input-wrapper">
+                        <ion-icon name="mail-outline"></ion-icon>
+                        <input
+                            id="register-username"
+                            type="text"
+                            name="username"
+                            value={userData.username}
+                            onChange={handleChange}
+                            placeholder="Придумайте логін"
+                        />
                     </div>
-  <button className="login">Зареєструватися</button>
-  
-  <div className="footer1"><span><a href='/users/login'>Вхід в акаунт</a></span></div>
-  
-</div>
-</form>
-</div>
+                </div>
+                <div className="auth-field">
+                    <label className="auth-label" htmlFor="register-password">Пароль</label>
+                    <div className="auth-input-wrapper">
+                        <ion-icon name="lock-closed-outline"></ion-icon>
+                        <input
+                            id="register-password"
+                            className="auth-password"
+                            type="password"
+                            name="password"
+                            placeholder="·········"
+                            value={userData.password}
+                            onChange={handleChange}
+                        />
+                        <ion-icon className="show-hide" name="eye-outline"></ion-icon>
+                    </div>
+                </div>
+                <div className="auth-field">
+                    <label className="auth-label" htmlFor="register-role">Оберіть роль</label>
+                    <select
+                        id="register-role"
+                        name="user_type"
+                        value={userData.user_type}
+                        onChange={handleChange}
+                        className="auth-select"
+                    >
+                        <option value="student">Студент</option>
+                        <option value="teacher">Викладач</option>
+                    </select>
+                </div>
+                <div className="auth-terms">
+                    <label className="auth-terms-label" htmlFor="agree">
+                        <input
+                            id="agree"
+                            type="checkbox"
+                            checked={agree}
+                            onChange={handleCheckboxChange}
+                        />
+                        <span>Я погоджуюся з <a href='/rules'>правилами користування чатботом</a></span>
+                    </label>
+                </div>
+                <button className="auth-submit" type="submit">Зареєструватися</button>
+                <div className="auth-footer">
+                    <span>Вже маєте акаунт?</span>
+                    <a href='/users/login'>Вхід в акаунт</a>
+                </div>
+            </form>
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary
- restyle the login and registration views to match the app's dark theme and typography
- replace ad-hoc markup with centered auth cards that add rounded corners, shadows, and improved layout
- add shared authentication form styles for inputs, buttons, and helper text

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68fab38e0a6c832397e379e3812cc7e4