### PR TITLE
Improve mobile responsiveness of chat interface

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -110,6 +110,31 @@ body {
   margin: 0 auto;
 }
 
+@media (max-width: 1200px) {
+  .chat-container {
+    width: min(92%, 1100px);
+  }
+}
+
+@media (max-width: 1024px) {
+  .App {
+    padding: 1.25rem 0 1rem;
+  }
+
+  .chat-container {
+    width: 95%;
+  }
+
+  .chat-messages {
+    padding: 1.25rem;
+  }
+
+  .chat-input textarea,
+  .chat-input input {
+    font-size: 0.95rem;
+  }
+}
+
 .chat-history-container {
   width: 30%;
   display: flex;
@@ -576,30 +601,153 @@ button {
 @media screen and (max-width: 768px) {
   .App {
     flex-direction: column;
-    padding: 1.5rem 0;
+    padding: 1rem 0.75rem 1.25rem;
     overflow: auto;
     height: auto;
+    gap: 1.25rem;
+  }
+
+  .headline {
+    padding: 1rem 0.5rem;
+  }
+
+  .headline a {
+    font-size: 1.1rem;
+    display: inline-block;
+    padding: 0 0.5rem;
   }
 
   .chat-container {
     flex-direction: column;
-    width: 95%;
+    width: 100%;
     height: auto;
+    border-radius: 16px;
   }
 
   .chat-history-container {
     width: 100%;
     border-right: none;
     border-bottom: 1px solid var(--border-subtle);
+    max-height: 40vh;
+    overflow-y: auto;
+  }
+
+  .chat-history {
+    padding: 0 0.5rem 1rem;
   }
 
   .chat-ui {
     width: 100%;
   }
 
+  .chat-messages {
+    padding: 1rem;
+  }
+
+  .chat-input {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .chat-input textarea,
+  .chat-input input {
+    min-height: 120px;
+    padding: 0.75rem;
+  }
+
+  .chat-input > div {
+    display: flex;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .chat-input > div button {
+    flex: 1;
+  }
+
+  .chat-input .image-upload-button {
+    width: 2.75rem;
+    height: 2.75rem;
+    flex: 0 0 auto;
+  }
+
+  .chat-input button {
+    width: 100%;
+  }
+
+  .new-chat-button {
+    width: 100%;
+    font-size: 1rem;
+  }
+
+  .platform-switcher,
+  .model-switcher {
+    padding: 0.75rem 1rem;
+    gap: 0.5rem;
+  }
+
+  .profile-square {
+    border-radius: 0;
+  }
+
   .profile-flex {
     flex-direction: column;
     gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .footer {
+    padding: 1rem 0.5rem 0.75rem;
+    font-size: 0.95rem;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .headline a {
+    font-size: 1rem;
+  }
+
+  .chat-messages {
+    padding: 0.75rem;
+  }
+
+  .message {
+    max-width: 100%;
+    font-size: 0.9rem;
+  }
+
+  .chat-input {
+    padding: 0.75rem;
+    gap: 0.65rem;
+  }
+
+  .chat-input textarea,
+  .chat-input input {
+    min-height: 110px;
+    font-size: 0.9rem;
+  }
+
+  .chat-input > div {
+    flex-direction: column;
+  }
+
+  .chat-input .image-upload-button {
+    align-self: center;
+  }
+
+  .chat-input button {
+    padding: 0.75rem 1rem;
+  }
+
+  .model-info {
+    font-size: 0.8rem;
+  }
+
+  .modal {
+    width: min(90%, 360px);
+    padding: 1.5rem 1.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust layout spacing and container widths for medium viewports
- rework chat and history panels to stack cleanly on mobile screens
- tune chat input, modal, and footer styles for smaller devices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fab8fb194c8323b9e0a3dfdf560b05