### PR TITLE
Ensure backend dependencies install without project sources

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -13,7 +13,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip install --no-cache-dir poetry gunicorn \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-interaction --no-ansi
+    && poetry install --without dev --no-interaction --no-ansi --no-root
 
 COPY src ./src
 


### PR DESCRIPTION
## Summary
- use the supported `poetry install --without dev` flag in the backend Dockerfile to avoid install errors when building dependencies without source files

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692842e6091483238fc8d79b2e44c006)