### PR TITLE
Update docker ports for frontend and backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+    ports:
+      - "8090:8090"
     expose:
-      - "8000"
+      - "8090"
 
   migrate:
     build:
@@ -39,7 +41,7 @@ services:
       context: .
       dockerfile: docker/frontend.Dockerfile
     ports:
-      - "80:80"
+      - "3090:80"
     depends_on:
       - backend
     volumes:

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -22,6 +22,6 @@ ENV PYTHONPATH=/app/src
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 8000
+EXPOSE 8090
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,4 +11,4 @@ fi
 python manage.py migrate --noinput
 python manage.py collectstatic --noinput
 
-exec gunicorn web_aplication.wsgi:application --bind 0.0.0.0:8000 --workers 3
+exec gunicorn web_aplication.wsgi:application --bind 0.0.0.0:8090 --workers 3

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,7 +12,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://backend:8090;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -12,7 +12,7 @@ upstream frontend {
 }
 
 upstream backend {
-    server backend:8000;
+    server backend:8090;
 }
 
 


### PR DESCRIPTION
## Summary
- expose the backend service on port 8090 and update related container configs
- expose the frontend/nginx service on host port 3090 for access matching previous local setup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928476fe22c8323a5de91464e3ac174)