### PR TITLE
Fix nginx config for frontend routing

### DIFF
--- a/frontend/nginx/default_nginx.conf
+++ b/frontend/nginx/default_nginx.conf
@@ -2,6 +2,14 @@ server {
 
   listen 80;
 
+  location /api/ {
+    proxy_pass http://backend:8090;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -7,35 +7,7 @@ events {
     worker_connections  1024;
 }
 
-upstream frontend {
-    server nginx:80;
-}
-
-upstream backend {
-    server backend:8090;
-}
-
-
 http {
-    server {
-    listen 80;
-
-    location / {
-        proxy_pass http://frontend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /api/ {
-        proxy_pass http://backend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
     server_tokens off;
@@ -48,5 +20,6 @@ http {
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     keepalive_timeout  65;
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary
- simplify nginx base configuration to rely on standard includes
- proxy API requests directly to the backend while serving static assets locally

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69284e3bbca08323863a2a19ad427dc6)