### PR TITLE
Adjust Docker setup for dev servers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,16 +36,17 @@ services:
       - SQLITE_PATH=/data/db.sqlite3
       - STATIC_ROOT=/app/staticfiles
 
-  nginx:
+  frontend:
     build:
       context: .
       dockerfile: docker/frontend.Dockerfile
+    environment:
+      - HOST=0.0.0.0
+      - PORT=3090
     ports:
-      - "3090:80"
+      - "3090:3090"
     depends_on:
       - backend
-    volumes:
-      - static_volume:/staticfiles:ro
 
 volumes:
   static_volume:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,4 +11,4 @@ fi
 python manage.py migrate --noinput
 python manage.py collectstatic --noinput
 
-exec gunicorn web_aplication.wsgi:application --bind 0.0.0.0:8090 --workers 3
+exec python manage.py runserver 0.0.0.0:8090

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,28 +1,15 @@
-# Build stage
-FROM node:20-alpine AS builder
+FROM node:20-alpine
+
 WORKDIR /frontend
 
 COPY frontend/package*.json ./
 RUN npm ci
 
 COPY frontend .
-RUN npm run build || npm run build --if-present; \
-  mkdir -p /frontend/build_artifact; \
-  if [ -d build ]; then cp -r build/. /frontend/build_artifact/; \
-  elif [ -d dist ]; then cp -r dist/. /frontend/build_artifact/; \
-  else echo "No frontend build output found" && exit 1; fi
 
-# Production stage
-FROM nginx:stable-alpine
+ENV HOST=0.0.0.0
+ENV PORT=3090
 
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 3090
 
-# Copy built frontend assets
-RUN mkdir -p /usr/share/nginx/html
-COPY --from=builder /frontend/build_artifact /usr/share/nginx/html
-
-# Static files from Django will be mounted at runtime
-VOLUME ["/staticfiles"]
-
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- update backend container entrypoint to run the Django development server on port 8090
- rebuild the frontend image to run `npm start` on port 3090 instead of serving a built bundle through nginx
- update docker-compose to use the new frontend service and expose the correct ports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692851c56aac83239d86228ae4f16947)